### PR TITLE
file copy from debian/skeleton/, configurable parent directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 # Conventional directory for build output.
 build/
 preinst
+/.idea/
+/debian/
+C
+flutter_to_debian
+*.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,9 @@
 ## 1.0.2+1
 
 - add clarity about the Depends attribute in the debain.yaml file
+
+## 1.0.3
+
+- the parent directory is now configurable (instead of /opt)
+- the files in debian/skeleton will be copied: used for configuration files, documentation...
+

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Place the YMAL file in your Flutter project under ****<*project root*>*/debian/d
 flutter_app: 
   command: mega_cool_app
   arch: x64
+  parent: /usr/local/lib
 
 control:
   Package: Mega Cool App
@@ -30,11 +31,32 @@ This section of the **debain.yaml** file defines the application that will be pa
 flutter_app: 
   command: mega_cool_app
   arch: x64
+  parent: /usr/local/lib
 ```
 #### Command
 Points to the binary at your project's linux release bundle, and runs when debian package is invoked.
 #### arch
 the build architecture of your app.
+#### parent
+the app will be installed in a subdirectory <command> (like mega_cool_app) in this 
+directory.
+
+***default***: /opt
+
+
+***Example:***
+
+parent: /usr/local/lib
+
+the target directory is: /usr/local/lib/mega_cool_app
+
+## Additional files:
+If a directory debian/skeleton exists that files will be copied into the package. 
+
+This can be used for default configuration files.
+
+**Example:**
+The file debian/skeleton/etc/megacool/main.conf will be installed as /etc/megacool/main.conf
 
 ## Control
 This is what describes to the apt package manager or what ever piece of software you are using to install your app what it's all about.

--- a/bin/vars.dart
+++ b/bin/vars.dart
@@ -7,7 +7,7 @@ class Vars {
     File yaml = File("debian/debian.yaml");
 
     if (!(await yaml.exists())) {
-      throw Exception("Couldn't find debian.yaml in dedian/ folder");
+      throw Exception("Couldn't find debian.yaml in debian/ folder");
     }
 
     try {


### PR DESCRIPTION
- README.md: adapted to the new features
- All files from debian/skeleton/ will be copied into the *.deb
  Meaningful for default configuration files and documentation
- The parent of the target directory can be configured in debian.yaml
  Replaces the fix value /opt
- functions.dart: createFolders() must have "recursive: true"