### PR TITLE
feat: add execFieldCodes parameter to flutter_app in debian.yaml

### DIFF
--- a/bin/functions.dart
+++ b/bin/functions.dart
@@ -241,6 +241,9 @@ Future<void> addDesktopDataFiles(String package) async {
     } else if (mimeType.contains("desktop")) {
       final String appExecutableName =
           Vars.debianYaml["flutter_app"]["command"];
+      
+      final String execFieldCodes =
+          Vars.debianYaml["flutter_app"]["execFieldCodes"];
 
       desktop = await File(data.path).readAsString();
       desktop.trim();
@@ -255,13 +258,24 @@ Future<void> addDesktopDataFiles(String package) async {
       if (!desktop.endsWith("\n")) {
         desktop += "\n";
       }
-      desktop += "Exec=$execPath";
+    
+      var fieldCodes = '';
+      
+      final formattedFieldCodes = execFieldCodes.trim().replaceAll(' ', '').split(',');
+
+      for(final fieldCode in formattedFieldCodes) {
+        if(Vars.allowedExecFieldCodes.contains(fieldCode)) {
+          fieldCodes += '%$fieldCode ';
+        } else {
+          throw Exception("Field code %$fieldCode is not allowed");
+        }
+      }
+
+      desktop += "Exec=$execPath $fieldCodes";
       desktop += "\nTryExec=$execPath";
       desktopFileName = fileName;
     }
   }
-
-  // print("desktop: $desktop");
 
   await File(
     path.join(

--- a/bin/vars.dart
+++ b/bin/vars.dart
@@ -3,6 +3,9 @@ import 'dart:io';
 import 'package:yaml/yaml.dart';
 
 class Vars {
+
+  static const List<String> allowedExecFieldCodes = ['f','F','u', 'U', 'i', 'c', 'k'];
+
   static Future<void> parseDebianYaml() async {
     File yaml = File("debian/debian.yaml");
 


### PR DESCRIPTION
Add execFieldCodes to flutter_app entry in debian.yaml, so Exec property can take allowed arguments specified in https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s07.html

I also provided validation by allowed field codes.


