### PR TITLE
feat: add non-interactive installation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ flutter_app:
   command: mega_cool_app
   arch: x64
   parent: /usr/local/lib
+  nonInteractive: false
 
 control:
   Package: Mega Cool App
@@ -37,6 +38,7 @@ flutter_app:
   command: mega_cool_app
   arch: x64
   parent: /usr/local/lib
+  nonInteractive: false
 ```
 #### Command
 Points to the binary at your project's linux release bundle, and runs when debian package is invoked.
@@ -45,6 +47,8 @@ the build architecture of your app.
 #### parent
 the app will be installed in a subdirectory <command> (like mega_cool_app) in this 
 directory.
+### nonInteractive
+When true, no prompt for confirmation is displayed during package installation.
 
 ***default***: /opt
 


### PR DESCRIPTION
For packages meant for automated install, the interactive confirmation during pre-install is not desirable.
A new flag, `nonInteractive`, can be used in the yaml config to disable the default behavior.