### PR TITLE
Make field codes optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ flutter_app:
 Points to the binary at your project's linux release bundle, and runs when debian package is invoked.
 #### arch
 the build architecture of your app.
+#### execFieldCodes
+A comma-separated list of field codes for the `Exec` key in the desktop
+file.
+
+***Example***: `execFieldCodes: f,u,i`
+***Supported codes***: f, F, u, U, i, c, k
+
+Further information is available in the [FreeDesktop
+spec](https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s07.html).
 #### parent
 the app will be installed in a subdirectory <command> (like mega_cool_app) in this 
 directory.

--- a/bin/functions.dart
+++ b/bin/functions.dart
@@ -241,9 +241,6 @@ Future<void> addDesktopDataFiles(String package) async {
     } else if (mimeType.contains("desktop")) {
       final String appExecutableName =
           Vars.debianYaml["flutter_app"]["command"];
-      
-      final String execFieldCodes =
-          Vars.debianYaml["flutter_app"]["execFieldCodes"];
 
       desktop = await File(data.path).readAsString();
       desktop.trim();
@@ -258,20 +255,9 @@ Future<void> addDesktopDataFiles(String package) async {
       if (!desktop.endsWith("\n")) {
         desktop += "\n";
       }
-    
-      var fieldCodes = '';
-      
-      final formattedFieldCodes = execFieldCodes.trim().replaceAll(' ', '').split(',');
 
-      for(final fieldCode in formattedFieldCodes) {
-        if(Vars.allowedExecFieldCodes.contains(fieldCode)) {
-          fieldCodes += '%$fieldCode ';
-        } else {
-          throw Exception("Field code %$fieldCode is not allowed");
-        }
-      }
-
-      desktop += "Exec=$execPath $fieldCodes";
+      final fieldCodes = formatFieldCodes();
+      desktop += fieldCodes == "" ? "Exec=$execPath" : "Exec=$execPath $fieldCodes";
       desktop += "\nTryExec=$execPath";
       desktopFileName = fileName;
     }
@@ -283,6 +269,30 @@ Future<void> addDesktopDataFiles(String package) async {
       desktopFileName,
     ),
   ).writeAsString(desktop);
+}
+
+
+String formatFieldCodes() {
+  final String execFieldCodes =
+      Vars.debianYaml["flutter_app"]["execFieldCodes"] ?? "";
+
+  if (execFieldCodes == "") {
+    return "";
+  }
+
+  var fieldCodes = '';
+
+  final formattedFieldCodes = execFieldCodes.trim().replaceAll(' ', '').split(',');
+
+  for(final fieldCode in formattedFieldCodes) {
+    if(Vars.allowedExecFieldCodes.contains(fieldCode)) {
+      fieldCodes += '%$fieldCode ';
+    } else {
+      throw Exception("Field code %$fieldCode is not allowed");
+    }
+  }
+
+  return fieldCodes;
 }
 
 Future<void> createFileStructure() async {


### PR DESCRIPTION
Package build should not fail if `execFieldCodes` is not specified.

Also documents `execFieldCodes` in README.