### PR TITLE
refactor: Support using as direct dependency (move functionality)

### DIFF
--- a/bin/flutter_to_debian.dart
+++ b/bin/flutter_to_debian.dart
@@ -14,55 +14,89 @@ void main(List<String> arguments) async {
   exitCode = 0;
 
   final parser = ArgParser()
-    ..addCommand(cmdDependencies, DependencyFinder.getArgParser())
+    ..addCommand(cmdDependencies, DependencyFinderArgParser.createParser())
     ..addCommand(cmdHelp)
-    ..addCommand(cmdCreate, FlutterToDebian.getArgParser())
-    ..addCommand(cmdBuild, FlutterToDebian.getArgParser());
+    ..addCommand(cmdCreate, BuildArgParser.createParser())
+    ..addCommand(cmdBuild, BuildArgParser.createParser());
 
   ArgResults argResults = parser.parse(arguments);
   final restArgs = argResults.rest;
 
-  if (argResults.command?.name == cmdDependencies) {
-    await dependencies(argResults.command!);
-  } else if (argResults.command?.name == cmdHelp) {
-    usage(null); // TODO: use built in help function from ArgParser
-  } else if (argResults.command == null ||
-      argResults.command?.name == cmdBuild ||
-      argResults.command?.name == cmdCreate) {
-    stdout.write("\nchecking for debian 📦 in root project...");
+  final command = argResults.command;
+
+  if (command == null || command.name == cmdBuild) {
     try {
-      var flutterToDebian = await FlutterToDebian.load();
-
-      if (argResults.command != null) {
-        // Apply build args
-        final buildArgResults = argResults.command!;
-        // final buildRestArgs = buildArgResults.rest;
-        flutterToDebian.debianControl = flutterToDebian.debianControl.copyWith(
-          version: buildArgResults[optBuildVersion],
-        );
-      }
-
-      stdout.writeln("  ✅\n");
-      stdout.writeln("start building debian package... ♻️  ♻️  ♻️\n");
-      try {
-        if (argResults.command?.name == cmdCreate) {
-          await flutterToDebian.createDesktopDataFiles(isOverride: true);
-          return;
-        }
-
-        final String execPath = await flutterToDebian.build();
-
-        stdout.writeln("🔥🔥🔥 (debian 📦) build done successfully  ✅\n");
-        stdout.writeln("😎 find your .deb at\n$execPath");
-      } catch (e) {
-        exitCode = 2;
-        rethrow;
-      }
+      await BuildArgParser.run(command);
     } catch (e) {
       exitCode = 2;
       rethrow;
     }
+  } else if (command.name == cmdCreate) {
+    try {
+      await CreateDirsArgParser.run(command);
+    } catch (e) {
+      exitCode = 2;
+      rethrow;
+    }
+  } else if (command.name == cmdDependencies) {
+    await DependencyFinderArgParser.run(command);
+  } else if (command.name == cmdHelp) {
+    usage(null); // TODO: use built in help function from ArgParser
   } else {
     usage('Unknown arguments: $restArgs');
+  }
+}
+
+class BuildArgParser {
+  static const optBuildVersion = 'build-version';
+  static const optArchitecture = 'arch';
+
+  static ArgParser createParser() {
+    return ArgParser()
+      ..addOption(optBuildVersion)
+      ..addOption(optArchitecture);
+  }
+
+  static Future<void> run(ArgResults? argResults) async {
+    await FlutterToDebian.runBuild(
+        version: argResults?[optBuildVersion],
+        arch: argResults?[optArchitecture]);
+  }
+}
+
+class CreateDirsArgParser {
+  static const optBuildVersion = 'build-version';
+
+  static ArgParser createParser() {
+    return ArgParser()..addOption(optBuildVersion);
+  }
+
+  static Future<void> run(ArgResults argResults) async {
+    await FlutterToDebian.runCreate(
+      version: argResults[optBuildVersion],
+    );
+  }
+}
+
+class DependencyFinderArgParser {
+  static const optExcludedLibs = 'excluded-libraries';
+  static const optExcludedPackages = 'excluded-packages';
+
+  static ArgParser createParser() {
+    return ArgParser()
+      ..addOption(optExcludedLibs)
+      ..addOption(optExcludedPackages);
+  }
+
+  /// Finds the dependencies of some library files.
+  static Future<void> run(ArgResults argResults) async {
+    final restArgs = argResults.rest;
+
+    final checker = DependencyFinder();
+    await checker.run(
+      excludedLibs: argResults[optExcludedLibs],
+      excludedPackages: argResults[optExcludedPackages],
+      fileArgs: restArgs,
+    );
   }
 }

--- a/bin/flutter_to_debian.dart
+++ b/bin/flutter_to_debian.dart
@@ -4,7 +4,6 @@ import 'package:args/args.dart';
 import 'package:flutter_to_debian/dependencies.dart';
 import 'package:flutter_to_debian/flutter_to_debian.dart';
 import 'package:flutter_to_debian/usage.dart';
-import 'package:flutter_to_debian/vars.dart';
 
 const cmdDependencies = 'dependencies';
 const cmdHelp = 'help';
@@ -32,21 +31,7 @@ void main(List<String> arguments) async {
       argResults.command?.name == cmdCreate) {
     stdout.write("\nchecking for debian 📦 in root project...");
     try {
-      var flutterToDebian = await Vars.parseDebianYaml();
-      if (flutterToDebian == null) {
-        flutterToDebian = await Vars.parsePubspecYaml();
-        if (flutterToDebian != null) {
-          final deps = await DependencyFinder().run();
-          flutterToDebian.debianControl =
-              flutterToDebian.debianControl.copyWith(
-            depends: deps.join(','),
-          );
-        }
-      }
-
-      if (flutterToDebian == null) {
-        throw Exception("Couldn't find debian/debian.yaml or pubspec.yaml");
-      }
+      var flutterToDebian = await FlutterToDebian.load();
 
       if (argResults.command != null) {
         // Apply build args

--- a/lib/dependencies.dart
+++ b/lib/dependencies.dart
@@ -1,23 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:args/args.dart';
 import 'package:yaml/yaml.dart';
-
-const optExcludedLibs = 'excluded-libraries';
-const optExcludedPackages = 'excluded-packages';
-
-/// Finds the dependencies of some library files.
-Future<List<String>> dependencies(ArgResults argResults) async {
-  final restArgs = argResults.rest;
-
-  final checker = DependencyFinder();
-  return checker.run(
-    excludedLibs: argResults[optExcludedLibs],
-    excludedPackages: argResults[optExcludedPackages],
-    fileArgs: restArgs,
-  );
-}
 
 /// A manager for detecting library dependencies in a Debian environment.
 class DependencyFinder {
@@ -27,12 +11,6 @@ class DependencyFinder {
   RegExp? excludedArchitecture;
   RegExp? excludedLibs;
   List<String> excludedPackages = [];
-
-  static ArgParser getArgParser() {
-    return ArgParser()
-      ..addOption(optExcludedLibs)
-      ..addOption(optExcludedPackages);
-  }
 
   Future<List<String>> run({
     String? excludedLibs,

--- a/lib/flutter_to_debian.dart
+++ b/lib/flutter_to_debian.dart
@@ -1,14 +1,11 @@
 import 'dart:io';
 
-import 'package:args/args.dart';
 import 'package:flutter_to_debian/debian_control.dart';
 import 'package:flutter_to_debian/dependencies.dart';
 import 'package:flutter_to_debian/vars.dart';
 import 'package:mime_type/mime_type.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
-
-const optBuildVersion = 'build-version';
 
 class FlutterToDebian {
   String appExecutableName = '';
@@ -21,11 +18,44 @@ class FlutterToDebian {
 
   String execOutDirPath = 'build/linux/x64/release/debian';
 
-  static ArgParser getArgParser() {
-    return ArgParser()..addOption(optBuildVersion);
+  static Future<String> runBuild({String? version, String? arch}) async {
+    final flutterToDebian = await FlutterToDebian.fromConfigs();
+
+    if (version != null) {
+      flutterToDebian.debianControl = flutterToDebian.debianControl.copyWith(
+        version: version,
+      );
+    }
+
+    if (arch != null) {
+      flutterToDebian.flutterArch = arch;
+      flutterToDebian.execOutDirPath =
+          flutterToDebian.execOutDirPath.replaceAll('x64', arch);
+    }
+
+    stdout.writeln("start building debian package... ♻️  ♻️  ♻️\n");
+    final String execPath = await flutterToDebian.build();
+
+    stdout.writeln("🔥🔥🔥 (debian 📦) build done successfully  ✅\n");
+    stdout.writeln("😎 find your .deb at\n$execPath");
+    return execPath;
   }
 
-  static Future<FlutterToDebian> load() async {
+  static Future<void> runCreate({String? version}) async {
+    final flutterToDebian = await FlutterToDebian.fromConfigs();
+
+    if (version != null) {
+      flutterToDebian.debianControl = flutterToDebian.debianControl.copyWith(
+        version: version,
+      );
+    }
+
+    await flutterToDebian.createDesktopDataFiles(isOverride: true);
+    stdout.writeln("Successfully created Debian GUI config  ✅\n");
+  }
+
+  static Future<FlutterToDebian> fromConfigs() async {
+    stdout.write("\nchecking for debian 📦 in root project...");
     var flutterToDebian = await Vars.parseDebianYaml();
     if (flutterToDebian == null) {
       flutterToDebian = await Vars.parsePubspecYaml();
@@ -39,6 +69,7 @@ class FlutterToDebian {
     if (flutterToDebian == null) {
       throw Exception("Couldn't find debian/debian.yaml or pubspec.yaml");
     }
+    stdout.writeln("  ✅\n");
     return flutterToDebian;
   }
 


### PR DESCRIPTION
In order to use all the libraries functionality, we can move some code into the main library, to not need to duplicate code, if use the lib as direct dependency.

```yaml
# pubspec.yaml
dependencies:
  #...
  flutter_to_debian: ^2.0.0
```
